### PR TITLE
fix: Optimize UI delays and popup behavior

### DIFF
--- a/src/clicknick/shared.ahk
+++ b/src/clicknick/shared.ahk
@@ -79,9 +79,9 @@ AutoExec() {
     SetDefaultMouseSpeed, 0
     
     ; Delays
-    SetControlDelay, 150
+    SetControlDelay, 0
     SetMouseDelay, 100
-    SetWinDelay, 200
+    SetWinDelay, 0
 }
 
 !`:: ; Alt + `


### PR DESCRIPTION
Optimize UI delays and popup behavior   

- Set AHK ControlDelay and WinDelay to 0 for faster interactions  
- Fix popup focus issues:  
    - Track/cancel pending after() calls to prevent leaks  
    - Force window activation and combobox focus more reliably
         